### PR TITLE
Add package mapset.

### DIFF
--- a/mapset/example_test.go
+++ b/mapset/example_test.go
@@ -1,0 +1,44 @@
+package mapset_test
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/creachadair/mds/mapset"
+)
+
+func Example() {
+	s := mapset.New(strings.Fields("a man a plan")...)
+
+	// Add individual elements.
+	s.Add("panama", "canal")
+
+	// Add the contents of another set.
+	t := mapset.New("plan", "for", "the", "future")
+	s.AddAll(t)
+
+	// Remove items and convert to a slice.
+	elts := s.Remove("a", "an", "the", "for").Slice()
+
+	// Clone and make other changes.
+	u := s.Clone().Remove("future", "plans")
+
+	// Do some basic comparisons.
+	fmt.Println("t intersects u:", t.Intersects(u))
+	fmt.Println("t equals u:", t.Equals(u))
+	fmt.Println()
+
+	// The slice is unordered, so impose some discipline.
+	sort.Strings(elts)
+	fmt.Println(strings.Join(elts, "\n"))
+	// Output:
+	// t intersects u: true
+	// t equals u: false
+	//
+	// canal
+	// future
+	// man
+	// panama
+	// plan
+}

--- a/mapset/mapset.go
+++ b/mapset/mapset.go
@@ -1,0 +1,148 @@
+// Package mapset implements a basic set type using a built-in map.
+//
+// The Set type is a thin wrapper on a built-in Go map, so a Set is not safe
+// for concurrent use without external synchronization.
+package mapset
+
+// A Set represents a set of distinct values. It is implemented via the
+// built-in map type, and the underlying map can also be used directly to add
+// and remove items and to iterate the contents.
+type Set[T comparable] map[T]struct{}
+
+// New constructs a set of the specified items. The result is never nil, even
+// if no items are provided.
+func New[T comparable](items ...T) Set[T] {
+	m := make(Set[T], len(items))
+	return m.add(items)
+}
+
+// NewSize constructs a new set preallocated to have space for n items.
+func NewSize[T comparable](n int) Set[T] { return make(Set[T], n) }
+
+// IsEmpty reports whether s is empty.
+func (s Set[T]) IsEmpty() bool { return len(s) == 0 }
+
+// Len reports the number of elements in s.
+func (s Set[T]) Len() int { return len(s) }
+
+// Clear removes all elements from s and returns s.
+func (s Set[T]) Clear() Set[T] {
+	for item := range s {
+		delete(s, item)
+	}
+	return s
+}
+
+// Clone returns a new set with the same contents as s.
+// The value returned is never nil.
+func (s Set[T]) Clone() Set[T] {
+	m := make(Set[T], len(s))
+	for item := range s {
+		m[item] = struct{}{}
+	}
+	return m
+}
+
+// Has reports whether t is present in the set.
+func (s Set[T]) Has(t T) bool { _, ok := s[t]; return ok }
+
+// Add adds the specified items to the set and returns s.
+func (s *Set[T]) Add(items ...T) Set[T] {
+	if *s == nil {
+		*s = make(Set[T], len(items))
+	}
+	return (*s).add(items)
+}
+
+func (s Set[T]) add(items []T) Set[T] {
+	for _, item := range items {
+		s[item] = struct{}{}
+	}
+	return s
+}
+
+// AddAll adds all the elements of set t to s and returns s.
+func (s *Set[T]) AddAll(t Set[T]) Set[T] {
+	if *s == nil {
+		*s = t.Clone()
+		return *s
+	}
+	return (*s).addAll(t)
+}
+
+func (s Set[T]) addAll(t Set[T]) Set[T] {
+	for item := range t {
+		s[item] = struct{}{}
+	}
+	return s
+}
+
+// Remove removes the specified items from the set and returns s.
+func (s Set[T]) Remove(items ...T) Set[T] {
+	if len(s) != 0 {
+		for _, item := range items {
+			delete(s, item)
+		}
+	}
+	return s
+}
+
+// RemoveAll removes all the elements of set t from s and returns s.
+func (s Set[T]) RemoveAll(t Set[T]) Set[T] {
+	if len(s) != 0 {
+		for item := range t {
+			delete(s, item)
+		}
+	}
+	return s
+}
+
+// Pop removes and returns an arbitrary element of s, if s is non-empty.
+// If s is empty, it returns a zero value.
+func (s Set[T]) Pop() T {
+	for item := range s {
+		delete(s, item)
+		return item
+	}
+	var zero T
+	return zero
+}
+
+// Intersects reports whether s and t share any elements in common.
+func (s Set[T]) Intersects(t Set[T]) bool {
+	lo, hi := s, t
+	if len(s) > len(t) {
+		lo, hi = hi, lo
+	}
+	for item := range lo {
+		if hi.Has(item) {
+			return true
+		}
+	}
+	return false
+}
+
+// Equals reports whether s and t contain exactly the same elements.
+func (s Set[T]) Equals(t Set[T]) bool {
+	if len(s) != len(t) {
+		return false
+	}
+	for item := range s {
+		if !t.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Slice returns a slice of the contents of s in arbitrary order.
+func (s Set[T]) Slice() []T {
+	if len(s) == 0 {
+		return nil
+	}
+	items := make([]T, 0, len(s))
+	for item := range s {
+		items = append(items, item)
+	}
+	return items
+}

--- a/mapset/mapset_test.go
+++ b/mapset/mapset_test.go
@@ -1,0 +1,174 @@
+package mapset_test
+
+import (
+	"testing"
+
+	"github.com/creachadair/mds/mapset"
+	"github.com/google/go-cmp/cmp"
+)
+
+func check[T comparable](t *testing.T, s mapset.Set[T], want ...T) mapset.Set[T] {
+	t.Helper()
+	m := make(mapset.Set[T], len(want))
+	for _, w := range want {
+		m[w] = struct{}{}
+	}
+	if n := s.Len(); n != len(m) {
+		t.Errorf("Wrong length: got %d, want %d", n, len(m))
+	}
+	if diff := cmp.Diff(m, s); diff != "" {
+		t.Errorf("Wrong contents (-want, +got):\n%s", diff)
+	}
+	return s
+}
+
+func TestBasic(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		check(t, mapset.New[string]())
+		check(t, mapset.Set[int]{})
+		check(t, mapset.NewSize[struct{ A string }](100))
+	})
+
+	t.Run("New", func(t *testing.T) {
+		check(t, mapset.New("a", "b"), "a", "b")
+		check(t, mapset.New(1, 2, 3), 1, 2, 3)
+	})
+
+	t.Run("Clone", func(t *testing.T) {
+		inputs := []string{"apple", "pear", "plum", "cherry"}
+		s1 := mapset.New(inputs...)
+		s2 := s1.Clone()
+		check(t, s1, inputs...)
+		check(t, s2, inputs...)
+
+		var s3 mapset.Set[int]
+		if c := s3.Clone(); c == nil {
+			t.Error("Clone of nil should not be nil")
+		}
+
+		s4 := mapset.New[float64]()
+		if s4 == nil {
+			t.Error("New should not return nil")
+		}
+		if c := s4.Clone(); c == nil {
+			t.Error("Clone of empty should not be nil")
+		}
+	})
+
+	t.Run("Clear", func(t *testing.T) {
+		s := check(t, mapset.New("a", "man", "a", "plan", "a", "canal"), "a", "man", "plan", "canal")
+		check(t, s.Clear())
+		if len(s) != 0 {
+			t.Error("Length after clear should be zero")
+		}
+	})
+
+	t.Run("Slice", func(t *testing.T) {
+		tests := [][]int{
+			nil,
+			{},
+			{1, 2, 3},
+			{4, 1, 8, 9},
+			{2, 2, 3, 2, 2},
+		}
+		for _, in := range tests {
+			s := check(t, mapset.New(in...), in...)
+			check(t, s, s.Slice()...)
+		}
+	})
+}
+
+func TestItems(t *testing.T) {
+	t.Run("Add", func(t *testing.T) {
+		s := check(t, mapset.New(2, 3, 5, 7), 2, 3, 5, 7)
+		check(t, s.Add(2, 5, 11, 13), 2, 3, 5, 7, 11, 13)
+		check(t, s, 2, 3, 5, 7, 11, 13)
+	})
+
+	t.Run("Remove", func(t *testing.T) {
+		s := check(t, mapset.New(2, 3, 5, 7, 11, 13, 17), 2, 3, 5, 7, 11, 13, 17)
+		check(t, s.Remove(13, 17, 2, 8, 4, 1), 3, 5, 7, 11)
+		check(t, s, 3, 5, 7, 11)
+	})
+
+	t.Run("AddAll", func(t *testing.T) {
+		s1 := check(t, mapset.New(1, 3, 5, 7), 1, 3, 5, 7)
+		s2 := check(t, mapset.New(2, 4, 6), 2, 4, 6)
+
+		check(t, s1.AddAll(s2), 1, 2, 3, 4, 5, 6, 7)
+		check(t, s1, 1, 2, 3, 4, 5, 6, 7)
+		check(t, s2, 2, 4, 6)
+	})
+
+	t.Run("RemoveAll", func(t *testing.T) {
+		s1 := check(t, mapset.New(1, 2, 3, 4, 5), 1, 2, 3, 4, 5)
+		s2 := check(t, mapset.New(2, 4, 6, 8, 10), 2, 4, 6, 8, 10)
+
+		check(t, s1.RemoveAll(s2), 1, 3, 5)
+		check(t, s1, 1, 3, 5)
+		check(t, s2, 2, 4, 6, 8, 10)
+	})
+
+	t.Run("Pop", func(t *testing.T) {
+		s := check(t, mapset.New(1, 2), 1, 2)
+		if got := s.Pop(); got != 1 && got != 2 {
+			t.Errorf("Pop: got %d, want 1 or 2", got)
+		}
+		if s.Len() != 1 {
+			t.Errorf("Length after Pop: got %d, want 1", s.Len())
+		}
+	})
+}
+
+func TestCompare(t *testing.T) {
+	t.Run("Intersects", func(t *testing.T) {
+		s1 := check(t, mapset.New(1, 2, 3, 4), 1, 2, 3, 4)
+
+		if s2 := check(t, mapset.New[int]()); s2.Intersects(s1) || s1.Intersects(s2) {
+			t.Error("Empty set should not intersect")
+		}
+
+		if s2 := check(t, mapset.New(3, 5, 7), 3, 5, 7); !s2.Intersects(s1) || !s1.Intersects(s2) {
+			t.Error("Sets should intersect")
+		}
+
+		if s2 := check(t, mapset.New(6, 8, 10), 6, 8, 10); s2.Intersects(s1) || s1.Intersects(s2) {
+			t.Error("Sets should not intersect")
+		}
+	})
+
+	t.Run("Equals", func(t *testing.T) {
+		s1 := check(t, mapset.New(1, 2, 3), 1, 2, 3)
+		t.Logf("Test needle: %+v", s1)
+
+		s2 := s1.Clone()
+		s3 := mapset.New(1, 2, 3, 4)
+		s4 := mapset.New(1, 2, 3)
+		s5 := mapset.New(2, 3)
+		s6 := mapset.New(1, 2, 4)
+
+		tests := []struct {
+			a, b mapset.Set[int]
+			want bool
+		}{
+			{s1, s2, true},
+			{s1, s3, false},
+			{s1, s4, true},
+			{s1, s5, false},
+			{s1, s6, false},
+
+			// Various permutations of empty.
+			{mapset.Set[int](nil), mapset.Set[int](nil), true}, // both nil
+			{mapset.New[int](), mapset.New[int](), true},       // both non-nil
+			{mapset.Set[int](nil), mapset.New[int](), true},    // one nil, one not
+		}
+		for _, test := range tests {
+			if eq := test.a.Equals(test.b); eq != test.want {
+				t.Errorf("Equals: got %v, want %v\na = %+v\nb = %+v", eq, test.want, test.a, test.b)
+			}
+			if eq := test.b.Equals(test.a); eq != test.want {
+				t.Errorf("Equals: got %v, want %v\na = %+v\nb = %+v", eq, test.want, test.a, test.b)
+			}
+		}
+	})
+}


### PR DESCRIPTION
This is a basic "set" implementation for comparable values using a Go map.  The package API is intentionally fairly minimal; the goal is to make some of the common patterns for using maps as sets more convenient to use without obscuring the flexibility of the underlying map.