### PR TITLE
mdiff: add support for reading patches from text

### DIFF
--- a/mdiff/example_test.go
+++ b/mdiff/example_test.go
@@ -1,7 +1,10 @@
 package mdiff_test
 
 import (
+	"fmt"
+	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/creachadair/mds/mdiff"
@@ -84,4 +87,80 @@ func ExampleFormatUnified() {
 	// -away
 	// +ran
 	// +home
+}
+
+func ExampleRead() {
+	const textDiff = `1,2d0
+< I
+< saw
+3a2
+> blind
+5,6c4,5
+< running
+< away
+---
+> ran
+> home`
+
+	p, err := mdiff.Read(strings.NewReader(textDiff))
+	if err != nil {
+		log.Fatalf("Read: %v", err)
+	}
+	printChunks(p.Chunks)
+
+	// Output:
+	//
+	// Chunk 1: left 1:3, right 1:1
+	//  edit 1.1: -[I saw]
+	// Chunk 2: left 4:4, right 2:3
+	//  edit 2.1: +[blind]
+	// Chunk 3: left 5:7, right 4:6
+	//  edit 3.1: ![running away:ran home]
+}
+
+func ExampleReadUnified() {
+	const textDiff = `@@ -1,3 +1 @@
+-I
+-saw
+ three
+@@ -3,2 +1,3 @@
+ three
++blind
+ mice
+@@ -4,3 +3,3 @@
+ mice
+-running
+-away
++ran
++home`
+
+	p, err := mdiff.ReadUnified(strings.NewReader(textDiff))
+	if err != nil {
+		log.Fatalf("ReadUnified: %v", err)
+	}
+	printChunks(p.Chunks)
+
+	// Output:
+	//
+	// Chunk 1: left 1:4, right 1:1
+	//  edit 1.1: -[I saw]
+	//  edit 1.2: =[three]
+	// Chunk 2: left 3:5, right 1:4
+	//  edit 2.1: =[three]
+	//  edit 2.2: +[blind]
+	//  edit 2.3: =[mice]
+	// Chunk 3: left 4:7, right 3:6
+	//  edit 3.1: =[mice]
+	//  edit 3.2: -[running away]
+	//  edit 3.3: +[ran home]
+}
+
+func printChunks(cs []*mdiff.Chunk) {
+	for i, c := range cs {
+		fmt.Printf("Chunk %d: left %d:%d, right %d:%d\n",
+			i+1, c.LStart, c.LEnd, c.RStart, c.REnd)
+		for j, e := range c.Edits {
+			fmt.Printf(" edit %d.%d: %v\n", i+1, j+1, e)
+		}
+	}
 }

--- a/mdiff/mdiff_test.go
+++ b/mdiff/mdiff_test.go
@@ -180,19 +180,36 @@ func TestFormat(t *testing.T) {
 	})
 }
 
-func TestReadUnified(t *testing.T) {
-	p, err := mdiff.ReadUnified(strings.NewReader(udiff))
-	if err != nil {
-		t.Fatalf("ReadUnified: unexpected error: %v", err)
-	}
-	logChunks(t, p.Chunks)
+func TestRead(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		p, err := mdiff.Read(strings.NewReader(odiff))
+		if err != nil {
+			t.Fatalf("Read: unexpected error: %v", err)
+		}
+		logChunks(t, p.Chunks)
 
-	// The output should round-trip.
-	var buf bytes.Buffer
-	mdiff.FormatUnified(&buf, &mdiff.Diff{Chunks: p.Chunks}, p.FileInfo)
-	if got := buf.String(); got != udiff {
-		t.Errorf("ReadUnified: got:\n%s\nwant:\n%s", got, udiff)
-	}
+		// The output should round-trip
+		var buf bytes.Buffer
+		mdiff.Format(&buf, &mdiff.Diff{Chunks: p.Chunks}, nil)
+		if got := buf.String(); got != odiff {
+			t.Errorf("Read: got:\n%s\nwant:\n%s", got, odiff)
+		}
+	})
+
+	t.Run("Unified", func(t *testing.T) {
+		p, err := mdiff.ReadUnified(strings.NewReader(udiff))
+		if err != nil {
+			t.Fatalf("ReadUnified: unexpected error: %v", err)
+		}
+		logChunks(t, p.Chunks)
+
+		// The output should round-trip.
+		var buf bytes.Buffer
+		mdiff.FormatUnified(&buf, &mdiff.Diff{Chunks: p.Chunks}, p.FileInfo)
+		if got := buf.String(); got != udiff {
+			t.Errorf("ReadUnified: got:\n%s\nwant:\n%s", got, udiff)
+		}
+	})
 }
 
 func logDiff(t *testing.T, d *mdiff.Diff) {

--- a/mdiff/reader.go
+++ b/mdiff/reader.go
@@ -1,0 +1,208 @@
+package mdiff
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/creachadair/mds/slice"
+)
+
+// A Patch is the parsed representation of a diff read from text format.
+type Patch struct {
+	FileInfo *FileInfo // nil if no file header was present
+	Chunks   []*Chunk
+}
+
+// ReadUnified reads a unified diff patch from r.
+func ReadUnified(r io.Reader) (*Patch, error) {
+	rd := &diffReader{br: bufio.NewReader(r)}
+	if err := readUnified(rd); err != nil {
+		return nil, err
+	}
+	return &Patch{FileInfo: rd.fileInfo, Chunks: rd.chunks}, nil
+}
+
+// A diffReader provides common plumbing for reading a text diff.  It keeps
+// track of line numbers and one line of lookahead, and accumulates information
+// about a file header, if one is present.
+type diffReader struct {
+	br    *bufio.Reader
+	ln    int
+	saved *string
+
+	fileInfo *FileInfo
+	chunks   []*Chunk
+}
+
+// readline reads the next available line from the input, or returns the pushed
+// back lookahead line if one is available.
+func (r *diffReader) readline() (string, error) {
+	if r.saved != nil {
+		out := *r.saved
+		r.saved = nil
+		return out, nil
+	}
+	line, err := r.br.ReadString('\n')
+	if err == io.EOF {
+		if line == "" {
+			return "", err
+		}
+		r.ln++
+		return line, nil
+	} else if err != nil {
+		return "", err
+	}
+	r.ln++
+	return strings.TrimSuffix(line, "\n"), nil
+}
+
+// unread pushes s on the front of the line buffer. Only one line of pushback
+// is supported.
+func (r *diffReader) unread(s string) { r.saved = &s }
+
+func parseFileLine(s string, timeFormat ...string) (string, time.Time) {
+	name, rest, ok := strings.Cut(s, "\t")
+	if ok {
+		for _, tf := range timeFormat {
+			if ts, err := time.Parse(tf, rest); err == nil {
+				return name, ts
+			}
+		}
+	}
+	return name, time.Time{}
+}
+
+// parseSpan parses a string in the format "xM,N" where x is an arbitrary
+// string prefix and M and N are positive integer values.
+// If the string has the format "xM' only, parseSpan returns M, 0.
+func parseSpan(tag, s string) (lo, hi int, err error) {
+	rest, ok := strings.CutPrefix(s, tag)
+	if !ok {
+		return 0, 0, fmt.Errorf("missing %q prefix", tag)
+	}
+	lohi := strings.SplitN(rest, ",", 2)
+	lo, err = strconv.Atoi(lohi[0])
+	if err != nil {
+		return 0, 0, err
+	}
+	if len(lohi) == 1 {
+		return lo, 0, nil
+	}
+	hi, err = strconv.Atoi(lohi[1])
+	if err != nil {
+		return 0, 0, err
+	}
+	return lo, hi, nil
+}
+
+// readUnified reads a unified diff from r, with an optional header.
+func readUnified(r *diffReader) error {
+	if err := readUnifiedHeader(r); err != nil {
+		return fmt.Errorf("diff header: %w", err)
+	}
+	for {
+		err := readUnifiedChunk(r)
+		if err == io.EOF {
+			return nil
+		} else if err != nil {
+			return err
+		}
+	}
+}
+
+// readUnifiedHeader reads a unified diff header from r.
+func readUnifiedHeader(r *diffReader) error {
+	lline, err := r.readline()
+	if err != nil {
+		return err
+	}
+	lhs, ok := strings.CutPrefix(lline, "--- ")
+	if !ok {
+		r.unread(lline)
+		return nil
+	}
+	var fi FileInfo
+	fi.Left, fi.LeftTime = parseFileLine(lhs, TimeFormat)
+
+	rline, err := r.readline()
+	if err != nil {
+		return err
+	}
+	rhs, ok := strings.CutPrefix(rline, "+++ ")
+	if !ok {
+		return errors.New("missing right header")
+	}
+	fi.Right, fi.RightTime = parseFileLine(rhs, TimeFormat)
+	r.fileInfo = &fi
+	return nil
+}
+
+// readUnifiedChunk reads a single unified diff chunk from r.
+func readUnifiedChunk(r *diffReader) error {
+	line, err := r.readline()
+	if err != nil {
+		return err
+	}
+
+	// Unified diff headers are "@@ -lspan +rspan @@".
+	// But git diff adds additional stuff after the second "@@" to give the
+	// reader context. To support that, we relax the format check slightly.
+	parts := strings.Fields(line)
+	if len(parts) < 4 || parts[0] != "@@" || parts[3] != "@@" {
+		return fmt.Errorf("line %d: invalid chunk header %q", r.ln, line)
+	}
+	llo, lhi, err := parseSpan("-", parts[1])
+	if err != nil {
+		return fmt.Errorf("line %d: left span: %w", r.ln, err)
+	}
+	rlo, rhi, err := parseSpan("+", parts[2])
+	if err != nil {
+		return fmt.Errorf("line %d: right span: %w", r.ln, err)
+	}
+
+	ch := &Chunk{LStart: llo, LEnd: llo + lhi, RStart: rlo, REnd: rlo + rhi}
+	add := func(op slice.EditOp, text string) {
+		if len(ch.Edits) == 0 || ch.Edits[len(ch.Edits)-1].Op != op {
+			ch.Edits = append(ch.Edits, Edit{Op: op})
+		}
+		e := slice.PtrAt(ch.Edits, -1)
+		switch op {
+		case slice.OpDrop, slice.OpEmit:
+			e.X = append(e.X, text)
+		case slice.OpCopy:
+			e.Y = append(e.Y, text)
+		default:
+			panic("unexpected operator " + string(op))
+		}
+	}
+
+nextLine:
+	for {
+		line, err := r.readline()
+		if err == io.EOF {
+			break // end of input, end of chunk
+		} else if line == "" {
+			return fmt.Errorf("line %d: unexpected blank line", r.ln)
+		}
+		switch line[0] {
+		case ' ': // context
+			add(slice.OpEmit, line[1:])
+		case '-': // deletion from lhs
+			add(slice.OpDrop, line[1:])
+		case '+': // addition from rhs
+			add(slice.OpCopy, line[1:])
+		case '@': // new chunk header (probably)
+			r.unread(line)
+			break nextLine
+		default:
+			return fmt.Errorf("line %d: unexpected prefix %c", r.ln, line[0])
+		}
+	}
+	r.chunks = append(r.chunks, ch)
+	return nil
+}


### PR DESCRIPTION
- Add a Patch type to represent a diff patch.
- Add Read and ReadUnified to parse textual diffs.
- Update Format to use diff chunks instead of raw edits.
