### PR TITLE
slice: add LNDS and LNDSFunc to compute longest non-decreasing subsequences

### DIFF
--- a/slice/edit.go
+++ b/slice/edit.go
@@ -6,9 +6,14 @@ import "fmt"
 //
 // This implementation takes Θ(mn) time and O(P·min(m, n)) space for inputs of
 // length m = len(as) and n = len(bs) and longest subsequence length P.
-func LCS[T comparable, Slice ~[]T](as, bs Slice) Slice { return lcs(equal, as, bs) }
+func LCS[T comparable, Slice ~[]T](as, bs Slice) Slice { return LCSFunc(as, bs, equal) }
 
-func lcs[T any, Slice ~[]T](eq func(a, b T) bool, as, bs Slice) Slice {
+// LCSFunc computes a longest common subsequence of as and bs, using
+// eq to compare elements.
+//
+// This implementation takes Θ(mn) time and O(P·min(m, n)) space for inputs of
+// length m = len(as) and n = len(bs) and longest subsequence length P.
+func LCSFunc[T any, Slice ~[]T](as, bs Slice, eq func(a, b T) bool) Slice {
 	if len(as) == 0 || len(bs) == 0 {
 		return nil
 	}
@@ -132,7 +137,7 @@ func EditScript[T comparable, Slice ~[]T](lhs, rhs Slice) []Edit[T] {
 
 // editScriptFunc computes an edit script using eq as an equality comparison.
 func editScriptFunc[T any, Slice ~[]T](eq func(a, b T) bool, lhs, rhs Slice) []Edit[T] {
-	lcs := lcs(eq, lhs, rhs)
+	lcs := LCSFunc(lhs, rhs, eq)
 
 	// To construct the edit sequence, i scans forward through lcs.
 	// For each i, we find the unclaimed elements of lhs and rhs prior to the

--- a/slice/lis.go
+++ b/slice/lis.go
@@ -1,0 +1,157 @@
+package slice
+
+import (
+	"cmp"
+)
+
+// Editorial note: "longest increasing subsequence" and "longest
+// non-decreasing subsequence" are a mouthful, so in this file
+// "subsequence" and "longest subsequence" imply the ordering, unless
+// explicitly specified otherwise.
+
+// LNDS computes a longest non-decreasing subsequence of vs.
+//
+// This implementation takes O(P·log(n)) time and O(n) space for
+// inputs of length n = len(vs) and longest subsequence length P. If
+// the longest subsequence is the entire input, it takes O(n) time and
+// O(n) space.
+func LNDS[T cmp.Ordered, Slice ~[]T](vs Slice) Slice {
+	return LNDSFunc(vs, cmp.Compare)
+}
+
+// LNDSFunc computes a longest non-decreasing subsequence of vs, in
+// the order determined by the cmp function. cmp must return a
+// negative number when a < b, a positive number when a > b, and zero
+// when a == b.
+//
+// This implementation takes O(P·log(n)) time and O(n) space for
+// inputs of length n = len(vs) and longest subsequence length P. If
+// the longest subsequence is the entire input, it takes O(n) time and
+// O(n) space.
+func LNDSFunc[T any, Slice ~[]T](vs Slice, cmp func(a, b T) int) Slice {
+	if len(vs) == 0 {
+		return vs
+	}
+
+	// At its core, the algorithm considers every possible
+	// non-decreasing subsequence of vs, and picks one of the
+	// longest. The naive implementation is quadratic in either time
+	// or space (see lis_test.go for the former). Thankfully, four
+	// optimizations let us achieve O(n·log(n)):
+	//
+	//   - Each element only gets to participate in creating the
+	//     longest subsequences it can, we discard all shorter
+	//     options. It might still participate in many subsequences of
+	//     that length, but that brings us to...
+	//   - We only need to remember one subsequence of every length,
+	//     the one whose final element is the smallest. This is the
+	//     tails array, and means that every new element will
+	//     contribute to exactly 0 or 1 subsequence.
+	//   - Elements always appear in the tails array in non-decreasing
+	//     order, so we can use a binary search to find the one
+	//     subsequence that a new element might contribute to. This
+	//     gets us O(log(n)) time per element, instead of O(n).
+	//   - Successive non-decreasing new elements always contribute to
+	//     the longest currently known subsequence, which is the final
+	//     entry of tails. If we check for this trivial case before
+	//     embarking on the binary search, elements that appear in
+	//     non-decreasing order can be processed in O(1) time rather
+	//     than O(log(n)).
+	//
+	// There are truly marvelous proofs of these optimizations, which
+	// this comment is too short to contain.
+
+	var (
+		// tails[L] is the index into vs for the final element of a
+		// subsequence of length L. If several such subsequences
+		// exist, tails keeps whichever has the smallest final
+		// element, according to cmp.
+		tails = make([]int, 1, len(vs))
+
+		// prev[i] is the index into vs for the element that comes
+		// before vs[i], in some subsequence tracked by tails. If
+		// vs[i] is the first element of that subsequence, prev[i] is
+		// -1.
+		//
+		// It's effectively the pointers of linked lists whose heads
+		// are tracked in tails.
+		prev = make([]int, len(vs))
+	)
+
+	// The loop is cleaner if it can assume that at least 1 element
+	// has already been processed. Run the first iteration directly.
+	prev[0] = -1
+	tails[0] = 0
+
+	for i := range vs[1:] {
+		// While the loop is cleaner if we lift out the first
+		// iteration, it's confusing to humans to have i be off-by-one
+		// from vs's natural indexing. Correct that here so the rest
+		// of the loop is easier to follow.
+		i++
+
+		idxOfBestTail := tails[len(tails)-1]
+		if cmp(vs[i], vs[idxOfBestTail]) >= 0 {
+			// Fast path: the i-th element extends the currently known
+			// longest subsequence.
+			prev[i] = idxOfBestTail
+			tails = append(tails, i)
+			continue
+		}
+
+		// Otherwise, the i-th element _must_ be an improvement over a
+		// shorter subsequence currently being tracked in tails. Find
+		// and replace it.
+		//
+		// Note we run the search over tails minus its final element,
+		// which avoids repeating the fast path's compare during the
+		// search. It doesn't change the outcome since the fast path
+		// eliminated the "beyond the end of tails" edge case.
+		replaceIdx := bisectRight(tails[:len(tails)-1], vs[i], func(idx int, target T) int {
+			return cmp(vs[idx], target)
+		})
+
+		// The new element is extending the subsequence tracked in
+		// replaceIdx-1. If we're replacing the singleton subsequence,
+		// we have to avoid the out of bounds read of tails.
+		if replaceIdx == 0 {
+			prev[i] = -1
+		} else {
+			prev[i] = tails[replaceIdx-1]
+		}
+		tails[replaceIdx] = i
+	}
+
+	// We can now iterate back through the longest subsequence and
+	// partition the input.
+	ret := make([]T, len(tails))
+	seqIdx := tails[len(tails)-1] // current longest subsequence element
+	for i := range ret {
+		ret[len(ret)-1-i] = vs[seqIdx]
+		seqIdx = prev[seqIdx]
+	}
+
+	return ret
+}
+
+// bisectRight returns the position where target should be inserted in
+// a sorted slice. If target is already present in the slice, the
+// returned position is one past the final existing occurrence.
+//
+// This is effectively a right-leaning variant of
+// slices.BinarySearch. It doesn't return a found bool, since by
+// definition it will never return an index equivalent to target.
+func bisectRight[T, U any, Slice ~[]T](vs Slice, target U, cmp func(T, U) int) (idx int) {
+	ln := len(vs)
+	low, high := uint(0), uint(ln)
+	for low < high {
+		mid := (low + high) / 2
+		if cmp(vs[mid], target) > 0 {
+			high = mid
+		} else {
+			low = mid + 1
+		}
+	}
+	ret := int(low)
+	return ret
+}

--- a/slice/lis_test.go
+++ b/slice/lis_test.go
@@ -1,0 +1,207 @@
+package slice_test
+
+import (
+	"cmp"
+	"math/rand"
+	"slices"
+	"testing"
+
+	"github.com/creachadair/mds/slice"
+	diff "github.com/google/go-cmp/cmp"
+)
+
+func TestLNDSAndLIS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []int
+		want []int
+	}{
+		{
+			name: "nil",
+		},
+		{
+			name: "empty",
+			in:   []int{},
+			want: []int{},
+		},
+		{
+			name: "singleton",
+			in:   []int{1},
+			want: []int{1},
+		},
+		{
+			name: "sorted",
+			in:   []int{1, 2, 3, 4},
+			want: []int{1, 2, 3, 4},
+		},
+		{
+			name: "backwards",
+			in:   []int{4, 3, 2, 1},
+			want: []int{1},
+		},
+		{
+			name: "organ_pipe",
+			in:   []int{1, 2, 3, 4, 3, 2, 1},
+			want: []int{1, 2, 3, 3},
+		},
+		{
+			name: "sawtooth",
+			in:   []int{0, 1, 0, -1, 0, 1, 0, -1},
+			want: []int{0, 0, 0, 0},
+		},
+		{
+			name: "A005132", // from oeis.org
+			in:   []int{0, 1, 3, 6, 2, 7, 13, 20, 12, 21, 11, 22, 10},
+			want: []int{0, 1, 3, 6, 7, 13, 20, 21, 22},
+		},
+		{
+			name: "swapped_pairs",
+			in:   []int{2, 1, 4, 3, 6, 5, 8, 7},
+			want: []int{1, 3, 5, 7},
+		},
+		{
+			name: "run_of_equals",
+			// swapped_pairs with more 3s sprinkled in.
+			in:   []int{2, 1, 3, 4, 3, 6, 3, 5, 8, 3, 7},
+			want: []int{1, 3, 3, 3, 3, 7},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := slice.LNDS(tc.in)
+			if diff := diff.Diff(got, tc.want); diff != "" {
+				t.Logf("Input was: %v", tc.in)
+				t.Logf("Got: %v", got)
+				t.Logf("Want: %v", tc.want)
+				t.Errorf("LNDS subsequence is wrong (-got+want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLNDSAgainstLCS(t *testing.T) {
+	t.Parallel()
+
+	// A result from literature relates LNDS and LCS:
+	//
+	//   len(LNDS(lst)) == len(LCS(lst, Sorted(lst)))
+	//
+	// Check that this holds true. Ideally we could also compare the
+	// actual resultant lists, but there's no guarantee that LNDS and
+	// LCS will return the _same_ longest increasing subsequence, if
+	// multiple options are available.
+
+	const numVals = 50
+	const numIters = 100
+	for i := 0; i < numIters; i++ {
+		input := randomInts(numVals)
+
+		gotLNDS := slice.LNDSFunc(input, cmp.Compare)
+
+		sorted := append([]int(nil), input...)
+		slices.Sort(sorted)
+		gotLCS := slice.LCS(input, sorted)
+
+		if got, want := len(gotLNDS), len(gotLCS); got != want {
+			t.Logf("Input: %v", input)
+			t.Errorf("len(LNDS(x)) = %v, want len(LCS(x, sorted(x))) = %v", got, want)
+		}
+	}
+}
+
+func TestLNDSRandom(t *testing.T) {
+	t.Parallel()
+
+	const numVals = 50
+	const numIters = 100
+
+	for i := 0; i < numIters; i++ {
+		input := randomInts(numVals)
+		want := quadraticLNDS(input)
+		got := slice.LNDSFunc(input, cmp.Compare)
+
+		if diff := diff.Diff(got, want); diff != "" {
+			t.Logf("Input: %v", input)
+			t.Logf("Got: %v", got)
+			t.Logf("Want: %v", want)
+			t.Errorf("LNDS subsequence is wrong (-got+want):\n%s", diff)
+		}
+	}
+}
+
+// quadraticLNDS returns the same longest increasing subsequence of
+// lst that slice.LNDSFunc returns, but using a quadratic recursive
+// search that is much slower, but more obviously correct by
+// inspection.
+func quadraticLNDS(lst []int) []int {
+	// better reports whether a is a better LNDS than b.
+	//
+	// a wins if it is longer, or if any of its elements is smaller
+	// than its counterpart in b.
+	better := func(a, b []int) bool {
+		if len(a) > len(b) {
+			return true
+		} else if len(a) < len(b) {
+			return false
+		}
+
+		for i := range a {
+			if a[i] < b[i] {
+				return true
+			} else if a[i] > b[i] {
+				return false
+			}
+		}
+		// a and b are completely equal, which can happen in the
+		// quadratic algorithm since we might generate permutations of
+		// indistinguishable equal elements. Returning false avoids a
+		// pointless copy.
+		return false
+	}
+
+	// findLNDS recursively constructs all possible increasing
+	// sequences of vs, updating best as it discovers better LNDS
+	// candidates.
+	var findLNDS func([]int, []int, []int) []int
+	findLNDS = func(vs, acc, best []int) (bestOfTree []int) {
+		if len(vs) == 0 {
+			if better(acc, best) {
+				best = append(best[:0], acc...)
+			}
+			return best
+		}
+
+		lnBest := len(best)
+		if lnBest > 0 && len(vs)+len(acc) < lnBest {
+			// can't possibly do better than what's already known,
+			// give up early.
+			return best
+		}
+
+		elt, vs := vs[0], vs[1:]
+		if len(acc) == 0 || elt >= acc[len(acc)-1] {
+			// elt could extend acc, try that
+			best = findLNDS(vs, append(acc, elt), best)
+		}
+		// and always try skipping elt
+		return findLNDS(vs, acc, best)
+	}
+
+	// Preallocate, so the recursion doesn't add insult to injury by
+	// allocating as well.
+	acc := make([]int, 0, len(lst))
+	best := make([]int, 0, len(lst))
+
+	return findLNDS(lst, acc, best)
+}
+
+func randomInts(N int) []int {
+	ret := make([]int, N)
+	for i := range ret {
+		ret[i] = rand.Intn(2 * N)
+	}
+	return ret
+}


### PR DESCRIPTION
Two commits, the first of which just makes LCSFunc public, for symmetry with the other `L*S` funcs.

I tried also throwing in LIS as a trivial modification to LNDS, but the tests immediately blew up in my face, so I'll send those as a separate PR once I've figured that out.