### PR TITLE
mdiff: fix a range bug in trimming overlapping context

### DIFF
--- a/mdiff/mdiff.go
+++ b/mdiff/mdiff.go
@@ -247,7 +247,7 @@ func UnifyChunks(cs []*Chunk) []*Chunk {
 		// original script edits.
 		if lap > 0 {
 			if end.Op == slice.OpEmit { // last has post-context
-				if lap == len(end.X) { // remove the whole edit
+				if lap >= len(end.X) { // remove the whole edit
 					last.Edits = last.Edits[:len(last.Edits)-1]
 					end = slice.PtrAt(last.Edits, -1)
 				} else {
@@ -257,7 +257,7 @@ func UnifyChunks(cs []*Chunk) []*Chunk {
 				last.LEnd -= lap
 				last.REnd -= lap
 			} else if start.Op == slice.OpEmit { // start has pre-context
-				if lap == len(start.X) { // remove the whole edit
+				if lap >= len(start.X) { // remove the whole edit
 					c.Edits = c.Edits[1:]
 					start = slice.PtrAt(c.Edits, 0)
 				} else {

--- a/mdiff/mdiff_test.go
+++ b/mdiff/mdiff_test.go
@@ -84,6 +84,24 @@ func TestDiff(t *testing.T) {
 	})
 }
 
+func TestRegression(t *testing.T) {
+	t.Run("#12", func(t *testing.T) {
+		const contextWindow = 3
+
+		// Produce a chunk with a longer overlap than the size of the context
+		// window.  Without the fix, this will trigger a panic in unification.
+		lhs := mstr.Lines("X\nY\nZ\n\na\nb\nc")
+		rhs := mstr.Lines("X\nY\nZ\n\n\na\n\nb\n\nc\n\n")
+
+		d := mdiff.New(lhs, rhs)
+		t.Log("-- Before context")
+		logChunks(t, d.Chunks)
+		d.AddContext(contextWindow).Unify()
+		t.Log("-- After unification")
+		logChunks(t, d.Chunks)
+	})
+}
+
 func TestNoAlias(t *testing.T) {
 	// The documentation promises that adding context and unifying does not
 	// disturb the original edit sequence.

--- a/mdiff/mdiff_test.go
+++ b/mdiff/mdiff_test.go
@@ -90,8 +90,8 @@ func TestRegression(t *testing.T) {
 
 		// Produce a chunk with a longer overlap than the size of the context
 		// window.  Without the fix, this will trigger a panic in unification.
-		lhs := mstr.Lines("X\nY\nZ\n\na\nb\nc")
-		rhs := mstr.Lines("X\nY\nZ\n\n\na\n\nb\n\nc\n\n")
+		lhs := lines("X", "Y", "Z", "", "a", "b", "c")
+		rhs := lines("X", "Y", "Z", "", "", "a", "", "b", "", "c", "")
 
 		d := mdiff.New(lhs, rhs)
 		t.Log("-- Before context")
@@ -300,3 +300,5 @@ func logChunks(t *testing.T, cs []*mdiff.Chunk) {
 		}
 	}
 }
+
+func lines(ss ...string) []string { return ss }


### PR DESCRIPTION
When unifying chunks that overlap due to context, it is possible the amount of
overlap may exceed the size of the context chunk itself. The code accidentally
treated this as a partial overlap, causing a slice bounds error.

Add a regression test.

Fixes #12
