### PR TITLE
slice: deprecate Reverse, shim to the equivalent stdlib slices.Reverse

### DIFF
--- a/mdiff/mdiff.go
+++ b/mdiff/mdiff.go
@@ -66,6 +66,8 @@
 package mdiff
 
 import (
+	"slices"
+
 	"github.com/creachadair/mds/slice"
 )
 
@@ -189,7 +191,7 @@ func (d *Diff) findContext(c *Chunk, n int) (pre, post []string) {
 		}
 		pre = append(pre, d.Left[p]) // they are equal, so pick one
 	}
-	slice.Reverse(pre) // we walked backward from the start
+	slices.Reverse(pre) // we walked backward from the start
 
 	for i := 0; i < n; i++ {
 		p, q := lend+i, rend+i

--- a/slice/edit.go
+++ b/slice/edit.go
@@ -1,6 +1,9 @@
 package slice
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
 // LCS computes a longest common subsequence of as and bs.
 //
@@ -64,7 +67,7 @@ func LCSFunc[T any, Slice ~[]T](as, bs Slice, eq func(a, b T) bool) Slice {
 	for p := c[len(as)]; p.n > 0; p = p.prev {
 		out = append(out, as[p.i])
 	}
-	Reverse(out)
+	slices.Reverse(out)
 	return out
 }
 

--- a/slice/example_test.go
+++ b/slice/example_test.go
@@ -25,16 +25,6 @@ func ExampleDedup() {
 	// [1 3 2 4 5 1 3]
 }
 
-func ExampleReverse() {
-	vs := []string{"red", "yellow", "blue", "green"}
-	fmt.Println("before:", strings.Join(vs, " "))
-	slice.Reverse(vs)
-	fmt.Println("after:", strings.Join(vs, " "))
-	// Ouput:
-	// before: red yellow blue green
-	// after: green blue yellow red
-}
-
 func ExampleSplit() {
 	vs := []int{1, 2, 3, 4, 5, 6, 7, 8}
 

--- a/slice/example_test.go
+++ b/slice/example_test.go
@@ -18,13 +18,6 @@ func ExamplePartition() {
 	// [3 1 9 5 7]
 }
 
-func ExampleDedup() {
-	vs := []int{1, 1, 3, 2, 2, 4, 4, 5, 1, 3, 3, 3}
-	fmt.Println(slice.Dedup(vs))
-	// Output:
-	// [1 3 2 4 5 1 3]
-}
-
 func ExampleSplit() {
 	vs := []int{1, 2, 3, 4, 5, 6, 7, 8}
 

--- a/slice/slice.go
+++ b/slice/slice.go
@@ -79,11 +79,10 @@ func Dedup[T comparable](vs []T) []T {
 }
 
 // Reverse reverses the contents of vs in-place.
+//
+// Deprecated: Use the equivalent [slices.Reverse] instead.
 func Reverse[T any, Slice ~[]T](vs Slice) {
-	for i, j := 0, len(vs)-1; i < j; i++ {
-		vs[i], vs[j] = vs[j], vs[i]
-		j--
-	}
+	slices.Reverse(vs)
 }
 
 // Zero sets all the elements of vs to their zero value.

--- a/slice/slice_test.go
+++ b/slice/slice_test.go
@@ -62,29 +62,6 @@ func TestPartition(t *testing.T) {
 	}
 }
 
-func TestReverse(t *testing.T) {
-	tests := []struct {
-		name  string
-		input []int
-		want  []int
-	}{
-		{"Nil", nil, nil},
-		{"Empty", []int{}, nil},
-		{"Single", []int{11}, []int{11}},
-		{"Multiple", []int{1, 2, 3, 4, 5}, []int{5, 4, 3, 2, 1}},
-		{"Palindrome", []int{1, 2, 3, 2, 1}, []int{1, 2, 3, 2, 1}},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			cp := append([]int(nil), tc.input...)
-			slice.Reverse(cp)
-			if diff := cmp.Diff(tc.want, cp); diff != "" {
-				t.Errorf("Reverse(%v) result (-want, +got)\n%s", tc.input, diff)
-			}
-		})
-	}
-}
-
 func TestZero(t *testing.T) {
 	zs := []int{1, 2, 3, 4, 5}
 	slice.Zero(zs[3:])


### PR DESCRIPTION
Also one missed cleanup in the Dedup deprecation, as a separate cleanup commit: removed the example test for Dedup.