### PR TITLE
slice: rework Batches and Chunks to return iterators

### DIFF
--- a/slice/example_test.go
+++ b/slice/example_test.go
@@ -41,7 +41,7 @@ func ExampleRotate() {
 func ExampleChunks() {
 	vs := strings.Fields("my heart is a fish hiding in the water grass")
 
-	for _, c := range slice.Chunks(vs, 3) {
+	for c := range slice.Chunks(vs, 3) {
 		fmt.Println(c)
 	}
 	// Output:
@@ -54,7 +54,7 @@ func ExampleChunks() {
 func ExampleBatches() {
 	vs := strings.Fields("the freckles in our eyes are mirror images that when we kiss are perfectly aligned")
 
-	for _, b := range slice.Batches(vs, 4) {
+	for b := range slice.Batches(vs, 4) {
 		fmt.Println(b)
 	}
 	// Output:

--- a/slice/slice_test.go
+++ b/slice/slice_test.go
@@ -278,15 +278,15 @@ func TestChunks(t *testing.T) {
 		want  [][]string
 	}{
 		// An empty slice has only one covering.
-		{"", 0, [][]string{{}}},
-		{"", 1, [][]string{{}}},
-		{"", 5, [][]string{{}}},
+		{"", 0, nil},
+		{"", 1, nil},
+		{"", 5, nil},
 
-		{"x", 0, [][]string{{"x"}}},
+		{"x", 0, nil},
 		{"x", 1, [][]string{{"x"}}},
 		{"x", 2, [][]string{{"x"}}},
 
-		{"a b c d e", 0, [][]string{{"a", "b", "c", "d", "e"}}},
+		{"a b c d e", 0, nil},
 		{"a b c d e", 1, [][]string{{"a"}, {"b"}, {"c"}, {"d"}, {"e"}}},
 		{"a b c d e", 2, [][]string{{"a", "b"}, {"c", "d"}, {"e"}}},
 		{"a b c d e", 3, [][]string{{"a", "b", "c"}, {"d", "e"}}},
@@ -295,7 +295,7 @@ func TestChunks(t *testing.T) {
 		{"a b c d e", 6, [][]string{{"a", "b", "c", "d", "e"}}}, // n > len(input)
 	}
 	for _, tc := range tests {
-		got := slice.Chunks(strings.Fields(tc.input), tc.n)
+		got := slices.Collect(slice.Chunks(strings.Fields(tc.input), tc.n))
 		for i := range len(got) - 1 {
 			if len(got[i]) != tc.n {
 				t.Errorf("Chunk %d has length %d, want %d", i+1, len(got[i]), tc.n)
@@ -332,7 +332,7 @@ func TestBatches(t *testing.T) {
 		{100, [][]int{{1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10}, {11}, {12}, {13}}},
 	}
 	for _, tc := range tests {
-		got := slice.Batches(input, tc.n)
+		got := slices.Collect(slice.Batches(input, tc.n))
 		if diff := cmp.Diff(got, tc.want); diff != "" {
 			t.Errorf("Batches(%v, %d): (-got, +want)\n%s", input, tc.n, diff)
 		}


### PR DESCRIPTION
Instead of a slice of results, return a single-valued iterator over the
selected components. A caller who wants the actual slices can use the
slices.Collect helper:

    old := slice.Batches(vs, n)
    new := slices.Collect(slice.Batches(vs, n))

Existing use in the target of a range do not need to change, except for
updating the target variables:

    for _, c := range slice.Chunks(vs, n) {

becomes

    for c := range slice.Chunks(vs, n) {
