### PR TITLE
cache: add support for expiration of keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ This repository defines generic data structures and utility types in Go.
 
 The packages in this module are intended to be leaf libraries, and MUST NOT
 depend on packages outside this module, excepting only packages from the Go
-standard library, as well as selected golang.org/x/* packages on a case-by-case
-basis.  Separate-package tests in this repository _may_ depend on other
-packages, but such dependencies must be minimized.
+standard library, [creachadair/msync](https://godoc.org/github.com/creachadair/msync),
+and selected golang.org/x/* packages on a case-by-case basis.  Separate-package
+tests in this repository _may_ depend on other packages, but such dependencies
+must be minimized.
 
 Packages within the module _may_ depend on each other, where appropriate.
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,11 +1,77 @@
 // Copyright (C) Michael J. Fromberger. All Rights Reserved.
 
 // Package cache implements a keyed cache for arbitrary values.
+//
+// # Overview
+//
+// Call [New] to construct a new, empty [Cache] from a [Config]. A minimal
+// config specifies the storage implemetation ([Store]) and a size limit for
+// the cache. For example, to create an LRU cache for int keys and string
+// values, with 10 slots, write:
+//
+//	c := cache.New(cache.LRU[int, string]().WithLimit(10))
+//
+// By default the limit is a number of entries in the cache. To use a different
+// value size measurement, call [Config.WithSizeFunc]. For example, to use the
+// length of the value string as its size, and to set the size limit to 1MiB,
+// write:
+//
+//	cfg := cache.LRU[int, string]().
+//	    WithLimit(1 << 20).
+//	    WithSizeFunc(cache.Length)
+//
+// The storage implementation determines the eviction policy. This package
+// provides [LRU] and [Sieve] implementations; you may also plug in your own
+// implementation with a different policy using [Config.WithStore].
+// A [Cache] is safe for concurrent use by multiple goroutines.
+//
+// ## Key Methods
+//
+// Add keys to the cache with [Cache.Put] or [Cache.PutWithExpiration].
+// Remove keys from the cache with [Cache.Remove] or [Cache.Clear].
+// Check whether a key is present with [Cache.Has]. This does not count as an
+// access of the key for accounting purposes.
+// Access the value of a key with [Cache.Get]. This counts as an access.
+// Use [Cache.Len] to report the number of entries present in the cache.
+// Use [Cache.Size] to report the total size of all entries in the cache.
+//
+// # Eviction
+//
+// By default, entries are evicted silently from the cache as needed to make
+// room for new entries. If you need to know when entries are evicted, use
+// [Config.OnEvict] to set a callback that will be executed synchronously for
+// each key/value pair evicted or removed from the cache. Note that replacing a
+// key with [Cache.Put] also counts as an eviction for the old value being
+// replaced.
+//
+// You can explicitly evict the most-eligible entry using [Cache.Pop].
+//
+// # Automatic Expiration
+//
+// The caller may request that a key should expire and be automatically removed
+// from the cache at or after a certain [time.Time].  Entries added by
+// [Cache.Put] do not expire. Use [Cache.PutWithExpiration] to specify that the
+// key being added should be automatically removed after the given time. Use
+// [Cache.SetExpiration] to add or update the expiration time of an existing
+// key in the cache.
+//
+// Expirations are processed promptly, but are not guaranteed to occur at
+// exactly the time specified.
+//
+// While any expirations are pending, a cache maintains a background goroutine
+// to remove expired keys. The goroutine exits automatically when no further
+// expirations are needed.  When you are finished using a cache that has
+// expiration times set, you should call [Cache.Clear] to discard all the keys
+// in the cache, so that this goroutine can be cleaned up. If you do not set
+// any expiration times, this is not necessary.
 package cache
 
 import (
 	"fmt"
 	"sync"
+	"time"
+
+	"github.com/creachadair/mds/cache/internal/expirer"
 )
 
 // A Cache is a cache mapping keys to values, with a fixed limit on its maximum
@@ -24,6 +90,7 @@ type Cache[Key comparable, Value any] struct {
 	// Set once at construction, read-only thereafter.
 	sizeOf  func(Value) int64
 	onEvict func(Key, Value)
+	expirer *expirer.Expirer[Key]
 
 	// TODO(creachadair): add metrics
 }
@@ -48,12 +115,66 @@ func (c *Cache[K, V]) Get(key K) (V, bool) {
 // Put adds or replaces the value for key in c, and reports whether the value
 // was successfully stored. Put reports false if the cache does not have room
 // to store the provided value; otherwise, the cache is updated and Put reports
-// true. If necessary, items are evicted from the cache to make room for the
-// new value. Which values are evicted is determined by the cache store.
+// true. This counts as an access of the value for accounting purposes.
+//
+// If necessary, items are evicted from the cache to make room for the new
+// value. Which values are evicted is determined by the cache store. If Put
+// replaces an existing value for key, the old value is also evicted.
+//
+// A key added or updated by Put does not expire. If Put replaces an existing
+// key that had an expiration time, that expiration is removed.
+// See [Cache.PutWithExpiration] and [Cache.SetExpiration].
 func (c *Cache[K, V]) Put(key K, val V) bool {
 	c.μ.Lock()
 	defer c.μ.Unlock()
+	return c.putLocked(key, val)
+}
 
+// PutWithExpiration behaves as [Cache.Put], and also sets the expiration time
+// for the specified key.
+//
+// If the specified key is already present in the cache, its value and deadline
+// are updated. If deadline is the zero time, an existing deadline (if any) is
+// removed. This counts as an access of the
+//
+// If the specified key is not already present in the cache, and deadline is in
+// the past (including the zero time), PutWithExpiration reports false without
+// modifying the cache.
+func (c *Cache[K, V]) PutWithExpiration(key K, val V, deadline time.Time) bool {
+	c.μ.Lock()
+	defer c.μ.Unlock()
+	if _, ok := c.store.Check(key); !ok && deadline.Before(time.Now()) {
+		return false
+	}
+	if c.putLocked(key, val) {
+		c.setExpirationLocked(key, deadline)
+		return true
+	}
+	return false
+}
+
+// SetExpiration sets or updates the expiration deadline for the specified key.
+// If deadline is the zero time, any pending expiration for key is removed, and
+// the key will not expire.  It reports whether the specified key is present in
+// c. This does not count as an access of the value for accounting purposes,
+// even if it modifies the expiration time for key.
+//
+// It is legal for deadline to be a non-zero time in the past, in which case
+// the key will be removed at the next available opportunity. However, if you
+// wish to remove a key immediately, prefer [Cache.Remove].
+func (c *Cache[K, V]) SetExpiration(key K, deadline time.Time) bool {
+	c.μ.Lock()
+	defer c.μ.Unlock()
+	if _, ok := c.store.Check(key); !ok {
+		return false
+	}
+	c.setExpirationLocked(key, deadline)
+	return true
+}
+
+// putLocked is the shared implementation of Put and PutWithExpiration.
+// Precondition: Caller holds c.μ.
+func (c *Cache[K, V]) putLocked(key K, val V) bool {
 	valSize := c.sizeOf(val)
 	if valSize > c.limit {
 		return false // this value will never fit
@@ -78,7 +199,8 @@ func (c *Cache[K, V]) Put(key K, val V) bool {
 }
 
 // Remove removes the specified key from c, and reports whether a value had
-// been cached for that key.
+// been cached for that key. If Remove reports true, the removed value is
+// reported as an eviction.
 func (c *Cache[K, _]) Remove(key K) bool {
 	c.μ.Lock()
 	defer c.μ.Unlock()
@@ -89,6 +211,16 @@ func (c *Cache[K, _]) Remove(key K) bool {
 		return true
 	}
 	return false
+}
+
+func (c *Cache[K, _]) removeExpired(key K) {
+	c.μ.Lock()
+	defer c.μ.Unlock()
+
+	if old, ok := c.store.Check(key); ok {
+		c.store.Remove(key)
+		c.dropKeyLockedInternal(key, old)
+	}
 }
 
 // Len reports the number of items present in the cache.
@@ -103,6 +235,7 @@ func (c *Cache[K, V]) Clear() {
 	c.μ.Lock()
 	defer c.μ.Unlock()
 
+	c.expirer.ClearExpirations()
 	for c.count > 0 {
 		c.dropKeyLocked(c.store.Evict())
 	}
@@ -113,14 +246,12 @@ func (c *Cache[K, V]) Clear() {
 
 // Pop evicts the most eligible eviction candidate from c and reports whether
 // anything was removed. If Pop reports false, it means c was empty.
-func (c *Cache[K, V]) Pop() (K, V, bool) {
+func (c *Cache[K, V]) Pop() (_ K, _ V, ok bool) {
 	c.μ.Lock()
 	defer c.μ.Unlock()
 
 	if c.count == 0 {
-		var kzero K
-		var vzero V
-		return kzero, vzero, false
+		return
 	}
 	k, v := c.store.Evict()
 	c.dropKeyLocked(k, v)
@@ -152,11 +283,31 @@ func New[K comparable, V any](config Config[K, V]) *Cache[K, V] {
 }
 
 // dropKeyLocked reports the removal of key and updates the cache size.
+// It also discards any pending expiration for the key.
 // Precondition: Caller holds c.μ.
 func (c *Cache[K, V]) dropKeyLocked(key K, value V) {
+	c.expirer.RemoveExpiration(key)
+	c.dropKeyLockedInternal(key, value)
+}
+
+func (c *Cache[K, V]) dropKeyLockedInternal(key K, value V) {
 	c.onEvict(key, value)
 	c.size -= c.sizeOf(value)
 	c.count--
+}
+
+// setExpirationLocked sets or updates the expiration time of key to deadline.
+// If deadline is the zero time, any expiration for key is removed.
+// Precondition: Caller holds c.μ.
+func (c *Cache[K, _]) setExpirationLocked(key K, deadline time.Time) {
+	if deadline.IsZero() {
+		c.expirer.RemoveExpiration(key)
+		return
+	}
+	if c.expirer == nil {
+		c.expirer = expirer.New[K](c.removeExpired) // lazy init
+	}
+	c.expirer.SetExpiration(key, deadline)
 }
 
 // A Config carries the settings for a cache implementation.
@@ -207,7 +358,8 @@ func (c Config[K, V]) WithSizeFunc(sizeOf func(V) int64) Config[K, V] { c.sizeOf
 // OnEvict returns a copy of c with its eviction callback set to f.
 //
 // If an eviction callback is set, it is called for each entry removed or
-// evicted from the cache.
+// evicted from the cache. Note that updating the entry for a given key also
+// records an eviction for the old value being replaced.
 func (c Config[K, V]) OnEvict(f func(K, V)) Config[K, V] { c.onEvict = f; return c }
 
 func (c Config[K, V]) sizeFunc() func(V) int64 {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -3,7 +3,11 @@
 package cache_test
 
 import (
+	"math/rand/v2"
+	"sync"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/creachadair/mds/cache"
 	"github.com/creachadair/mds/cache/internal/cachetest"
@@ -234,5 +238,188 @@ func TestSieve(t *testing.T) {
 		// decreasing order of visit time (the get of k2 above promoted it).
 		cachetest.Run(t, c, "clear", "len = 0", "size = 0")
 		wantVic(t, "k1", "k4", "k3", "k2", "k5", "k3")
+	})
+}
+
+func TestExpiration(t *testing.T) {
+	t.Run("Correctness", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			var vmu sync.Mutex
+			var victims []string
+			wantVic := func(want ...string) {
+				t.Helper()
+				vmu.Lock()
+				defer vmu.Unlock()
+				if diff := gocmp.Diff(victims, want); diff != "" {
+					t.Errorf("Evictions (-got, +want):\n%s", diff)
+				}
+			}
+
+			c := cache.New(cache.LRU[string, string]().
+				WithLimit(10).
+				OnEvict(func(_, val string) {
+					vmu.Lock()
+					defer vmu.Unlock()
+					victims = append(victims, val)
+				}))
+
+			t0 := time.Now()
+
+			// An ordinary key that does not expire.
+			cachetest.Run(t, c, "put a apple = true")
+
+			// A key with an expiration assigned at birth to t0+5s.
+			c.PutWithExpiration("b", "banana", t0.Add(5*time.Second))
+
+			// More unexpiring keys.
+			cachetest.Run(t, c,
+				"put c cherry = true",
+				"put d durian = true",
+				"put e elderberry = true",
+			)
+			wantVic()
+
+			// At t0+2s, add an expiration to c at t0+15s.
+			time.Sleep(2 * time.Second)
+			c.SetExpiration("c", time.Now().Add(15*time.Second))
+			wantVic()
+
+			// After t0+6s, "b" should have expired.
+			time.Sleep(4 * time.Second)
+			wantVic("banana")
+
+			// After t0+26s, "c" should have expired.
+			time.Sleep(20 * time.Second)
+			wantVic("banana", "cherry")
+
+			// Add an expiration for "a", then remove it before t fires
+			// Verify that "a" did not expire.
+			if !c.SetExpiration("a", t0.Add(5*time.Minute)) {
+				t.Error("Key a should have been present")
+			}
+			time.Sleep(time.Second)
+			if !c.SetExpiration("a", time.Time{}) {
+				t.Error("Key a should have been present")
+			}
+
+			time.Sleep(10 * time.Minute)
+			wantVic("banana", "cherry")
+
+			// Proposing a new key with an expiration in the past does not add anything.
+			if c.PutWithExpiration("q", "quince", time.Now().Add(-time.Hour)) {
+				t.Error("Key q should not have been added")
+			}
+
+			// Setting an expiration in the past evicts the key (at the next sync point).
+			c.SetExpiration("a", time.Now().Add(-time.Second))
+
+			synctest.Wait()
+			wantVic("banana", "cherry", "apple")
+
+			// Update "d" with a new value and expiration (in the future).
+			// This generates an eviction for "durian".
+			if !c.PutWithExpiration("d", "dragonfruit", time.Now().Add(time.Minute)) {
+				t.Error("Key d should have been updated")
+			}
+			wantVic("banana", "cherry", "apple", "durian")
+
+			// Update "d" with a new value and no expiration before that expires.
+			// This generates an eviction for "dragonfruit".
+			time.Sleep(time.Second)
+			if !c.Put("d", "dingleberry") {
+				t.Error("Key d should have been updated")
+			}
+
+			synctest.Wait()
+			wantVic("banana", "cherry", "apple", "durian", "dragonfruit")
+
+			// More time passes, but "d" should remain.
+			time.Sleep(5 * time.Minute)
+			wantVic("banana", "cherry", "apple", "durian", "dragonfruit") // i.e., not dingleberry
+
+			if !c.Has("d") {
+				t.Error("Key d should be present")
+			}
+
+			// If we remove a key (e) that has an expiration, the expiration should
+			// go with it.  Adding the same key back won't inherit the expiration.
+			c.SetExpiration("e", time.Now().Add(10*time.Minute))
+			time.Sleep(5 * time.Minute)
+			cachetest.Run(t, c, "remove e = true", "put e evilfruit = true")
+			wantVic("banana", "cherry", "apple", "durian", "dragonfruit", "elderberry")
+
+			time.Sleep(20 * time.Minute)
+			if !c.Has("e") {
+				t.Error("Key e should be present")
+			}
+			wantVic("banana", "cherry", "apple", "durian", "dragonfruit", "elderberry")
+
+			// A key not present should not affect state.
+			if c.SetExpiration("q", time.Now().Add(time.Hour)) {
+				t.Error("Key q should not be present")
+			}
+		})
+	})
+
+	t.Run("Cleanup", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			c := cache.New(cache.Sieve[int, string]().WithLimit(10))
+
+			// Add some pending expirations, to exercise that calling Clear releases them.
+			// If it does not, the synctest bubble will fail at exit because the maintenance
+			// goroutine will still be blocked.
+
+			c.PutWithExpiration(5, "apple", time.Now().Add(1*time.Minute))
+			c.PutWithExpiration(4, "pear", time.Now().Add(2*time.Minute))
+			c.PutWithExpiration(6, "cherry", time.Now().Add(3*time.Minute))
+
+			time.Sleep(90 * time.Second)
+
+			c.Clear()
+			if n := c.Len(); n != 0 {
+				t.Errorf("After clear: got %d items, want 0", n)
+			}
+		})
+	})
+
+	t.Run("Rolling", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			const maxEntries = 100
+			const numKeys = 2_000
+
+			c := cache.New(cache.LRU[int, int]().WithLimit(maxEntries))
+
+			// Push a bunch of keys through the cache, some with and some without
+			// expirations, to give the race detector something to work with.
+			var cur int
+			var elts int
+			for i := range numKeys {
+				cur++
+				if rand.Float64() <= 0.6 {
+					c.PutWithExpiration(i%(2*maxEntries), cur, time.Now().Add(rand.N(5*time.Second)))
+				} else {
+					c.Put(i%200, cur)
+				}
+				elts = max(elts, c.Len())
+				time.Sleep(rand.N(800 * time.Millisecond))
+			}
+			t.Logf("Done priming cache, %d items present (max %d)", c.Len(), elts)
+
+			// Sleep long enough that all expiring keys should go away.
+			time.Sleep(time.Hour)
+			after := c.Len()
+			t.Logf("After expiration is complete, %d items remain", after)
+
+			// Verify that no more items disappear after a longer wait.
+			time.Sleep(time.Hour)
+			if got := c.Len(); got != after {
+				t.Errorf("Expired count changed: got %d, want %d", got, after)
+			}
+
+			c.Clear()
+			if n := c.Len(); n != 0 {
+				t.Errorf("After clear: have %d elements, want 0", n)
+			}
+		})
 	})
 }

--- a/cache/internal/expirer/expirer.go
+++ b/cache/internal/expirer/expirer.go
@@ -1,0 +1,157 @@
+// Copyright (C) Michael J. Fromberger. All Rights Reserved.
+
+// Package expirer implements a type that manages timed expiration of keys.
+package expirer
+
+import (
+	"sync"
+	"time"
+
+	"github.com/creachadair/mds/heapq"
+	"github.com/creachadair/msync/trigger"
+)
+
+// An Expirer manages expiration deadlines for a collection of keys.
+// A nil value is ready for use (its methods silently do nothing).
+type Expirer[Key comparable] struct {
+	check     *trigger.Cond // signalled when the queue changes
+	removeKey func(Key)     // remove the specified key from the cache
+
+	μ       sync.Mutex
+	present map[Key]int // :: Key → offset in queue
+	queue   *heapq.Queue[timerKey[Key]]
+	running bool
+
+	// The queue is ordered in nondecreasing order by deadline, so that the
+	// earliest deadline is always at the front.
+}
+
+// New constructs a new empty [Expirer] that uses removeKey to report expired keys.
+// The removeKey callback must not be nil.
+func New[Key comparable](removeKey func(Key)) *Expirer[Key] {
+	if removeKey == nil {
+		panic("nil removeKey callback")
+	}
+	m := make(map[Key]int)
+	q := heapq.New(timerKey[Key].Compare).SetUpdate(func(t timerKey[Key], npos int) {
+		m[t.Key] = npos
+	})
+	return &Expirer[Key]{
+		check:     trigger.New(),
+		removeKey: removeKey,
+		present:   m,
+		queue:     q,
+	}
+}
+
+// SetExpiration adds or updates the expiration for key to deadline.
+// It does nothing if e == nil.
+func (e *Expirer[Key]) SetExpiration(key Key, deadline time.Time) {
+	if e == nil {
+		return
+	}
+	e.μ.Lock()
+	defer e.μ.Unlock()
+	e.startIfNeededLocked()
+	if i, ok := e.present[key]; ok {
+		e.queue.Remove(i)
+	}
+	e.queue.Add(timerKey[Key]{Key: key, Deadline: deadline})
+	e.check.Signal()
+}
+
+// RemoveExpiration removes any pending expiration for the specified key.
+// It does nothing if e == nil.
+func (e *Expirer[Key]) RemoveExpiration(key Key) {
+	if e == nil {
+		return
+	}
+	e.μ.Lock()
+	defer e.μ.Unlock()
+	if i, ok := e.present[key]; ok {
+		e.queue.Remove(i)
+		delete(e.present, key)
+		e.check.Signal()
+	}
+}
+
+// ClearExpirations discards all pending expirations for all keys.
+// It does nothing if e == nil.
+func (e *Expirer[Key]) ClearExpirations() {
+	if e == nil {
+		return
+	}
+	e.μ.Lock()
+	defer e.μ.Unlock()
+	e.queue.Clear()
+	clear(e.present)
+	e.check.Signal()
+}
+
+func (e *Expirer[Key]) startIfNeededLocked() {
+	if e.running {
+		return // already running
+	}
+	e.running = true
+
+	// Start the service goroutine for the expiration queue.
+	// This is started (or re-started) whenever the queue transitions from empty
+	// to non-empty, and runs until it has drained the queue completely.
+	go func() {
+		for {
+			changed := e.check.Ready()
+			wake, expired, isEmpty := e.scanQueue()
+			for _, key := range expired {
+				e.removeKey(key)
+			}
+			if isEmpty {
+				return // no more expirations are pending
+			}
+			select {
+			case <-wake:
+				// the deadline for the frontmost queue element has passed
+			case <-changed:
+				// the queue changed, so it is now possible that the last wakeup
+				// time we chose in scanQueue is no longer valid.
+			}
+		}
+	}()
+}
+
+// scanQueue removes and returnsall keys whose expiration is past from the
+// front of the queue, and reports whether the remaining queue is empty.
+//
+// If the queue is not empty, it also returns a channel that is ready when the
+// next unexpired item is expected to expire.
+func (e *Expirer[Key]) scanQueue() (wake <-chan time.Time, expired []Key, isEmpty bool) {
+	e.μ.Lock()
+	defer e.μ.Unlock()
+	now := time.Now()
+	for {
+		next, ok := e.queue.Peek(0)
+		if !ok {
+			break
+		}
+		if next.Deadline.After(now) {
+			return time.After(next.Deadline.Sub(now)), expired, false
+		}
+		e.queue.Pop()
+		delete(e.present, next.Key)
+		expired = append(expired, next.Key)
+	}
+
+	// The service goroutine is still running at this instant, but will exit
+	// without doing further work upon learning that the queue is now empty.
+	// Clear the flag now, so that if a new item arrives during the interval
+	// SetExpiration will know to start a new one.
+	e.running = false
+	return nil, expired, true
+}
+
+// A timerKey packages a cache key with an expiration deadline.
+type timerKey[Key any] struct {
+	Key      Key
+	Deadline time.Time
+}
+
+func (t timerKey[Key]) Compare(u timerKey[Key]) int { return t.Deadline.Compare(u.Deadline) }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/creachadair/mds
 
 go 1.25.0
 
-require github.com/google/go-cmp v0.7.0
+require (
+	github.com/creachadair/msync v0.10.0
+	github.com/google/go-cmp v0.7.0
+)
 
 require (
 	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/kWtOwnv/G+AzdKuy2ZrqINhenH4HyNs=
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/creachadair/msync v0.10.0 h1:2RlGs187RQN5tzyluKEkbkXq+LRK2KIR+An6FoB9x+M=
+github.com/creachadair/msync v0.10.0/go.mod h1:J+4p7as+O7NWydXYGJNrigY67qj1F1GB0CcTWyV/5AE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 h1:1P7xPZEwZMoBoz0Yze5Nx2/4pxj6nw9ZqHWXqP0iRgQ=


### PR DESCRIPTION
Add two new methods to the Cache type:

- PutWithExpiration(key, value, deadline) is as Put, but also sets an
  expiration time after which the key will automatically be removed.

- SetExpiration(key, deadline) modifies the expiration time for an existing key
  in the cache.

Expiration is managed by a separate goroutine that is started on-demand when
there are expirations pending, and which exits when no expiration is needed.
